### PR TITLE
Add GitHub Action to deploy website to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20' # Specify your Node.js version here
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build application
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AI Micro Site Test
 
+[![Deploy to GitHub Pages](https://github.com/donnycrash/jules-test/actions/workflows/deploy.yml/badge.svg)](https://github.com/donnycrash/jules-test/actions/workflows/deploy.yml)
+
 This is a test to see how well AI can generate an entire micro site—including layout, design, and written content—using only natural language instructions. The goal is to evaluate the capabilities of modern AI tools in automating web development tasks, from scaffolding a React/Vite project to producing production-ready UI components, copy, and deployment configuration.
 
 Additionally, this project serves as a benchmark to compare the performance and usability of Google's new agent Jules against other AI coding assistants. By building a real-world site from scratch, we can assess strengths, weaknesses, and the overall developer experience provided by these tools.


### PR DESCRIPTION
This commit adds a GitHub Actions workflow to automatically deploy the website to GitHub Pages when code is merged to the main branch.

The workflow does the following:
- Checks out the code
- Sets up Node.js
- Installs dependencies
- Builds the application
- Deploys the `dist` directory to the `gh-pages` branch

A badge has also been added to the README.md file to show the status of the deployment workflow.